### PR TITLE
Binder : force version of larray when building myBinder repo (issue 603)

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,4 +10,5 @@ dependencies:
   - pytables
   - bokeh
   - rise
-  - larray
+  - pip:
+    - larray

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1,6 +1,14 @@
 ﻿Change log
 ##########
 
+Version 0.29
+============
+
+In development.
+
+.. include:: ./changes/version_0_29.rst.inc
+
+
 Version 0.28
 ============
 

--- a/doc/source/changes/version_0_29.rst.inc
+++ b/doc/source/changes/version_0_29.rst.inc
@@ -1,0 +1,32 @@
+﻿Syntax changes
+--------------
+
+* new syntax
+
+
+Backward incompatible changes
+-----------------------------
+
+* backward incompatible changes
+
+
+New features
+------------
+
+* added a feature (see the :ref:`miscellaneous section <misc>` for details).
+
+* added another feature.
+
+
+.. _misc:
+
+Miscellaneous improvements
+--------------------------
+
+* improved something.
+
+
+Fixes
+-----
+
+* fixed something (closes :issue:`1`).

--- a/larray/__init__.py
+++ b/larray/__init__.py
@@ -7,4 +7,4 @@ from larray.example import *
 from larray.extra import *
 from larray.viewer import *
 
-__version__ = '0.28'
+__version__ = '0.29-dev'

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readlocal(fname):
 
 
 DISTNAME = 'larray'
-VERSION = '0.28'
+VERSION = '0.29-dev'
 AUTHOR = 'Gaetan de Menten, Geert Bryon, Johan Duyck, Alix Damman'
 AUTHOR_EMAIL = 'gdementen@gmail.com'
 DESCRIPTION = "N-D labeled arrays in Python"


### PR DESCRIPTION
Result here : https://mybinder.org/v2/gh/alixdamman/larray/binder_postbuild_603

I tried to use a postBuild script a few months ago but didn't work well. 
No, it seems to work really better. 
It seems like myBinder is under fast development right now...