### PR TITLE
include missing ufuncs doc to API documention

### DIFF
--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -444,17 +444,6 @@ Miscellaneous
    LArray.shift
    LArray.diff
    LArray.to_clipboard
-   round
-   floor
-   ceil
-   trunc
-   sqrt
-   absolute
-   fabs
-   where
-   isnan
-   isinf
-   nan_to_num
 
 .. _la_to_pandas:
 
@@ -476,6 +465,136 @@ Plotting
    :toctree: _generated/
 
    LArray.plot
+
+.. _api-ufuncs:
+
+Utility Functions
+=================
+
+* :ref:`ufuncs_misc`
+* :ref:`ufuncs_rounding`
+* :ref:`ufuncs_exp_log`
+* :ref:`ufuncs_trigo`
+* :ref:`ufuncs_hyper`
+* :ref:`ufuncs_complex`
+* :ref:`ufuncs_floating`
+
+.. _ufuncs_misc:
+
+Miscellaneous
+-------------
+
+.. autosummary::
+   :toctree: _generated/
+
+   where
+   maximum
+   minimum
+   inverse
+   interp
+   convolve
+   absolute
+   fabs
+   isnan
+   isinf
+   nan_to_num
+   sqrt
+   i0
+   sinc
+
+.. _ufuncs_rounding:
+
+Rounding
+--------
+
+.. autosummary::
+   :toctree: _generated/
+
+   round
+   floor
+   ceil
+   trunc
+   rint
+   fix
+
+.. _ufuncs_exp_log:
+
+Exponents And Logarithms
+------------------------
+
+.. autosummary::
+   :toctree: _generated/
+
+    exp
+    expm1
+    exp2
+    log
+    log10
+    log2
+    log1p
+    logaddexp
+    logaddexp2
+
+.. _ufuncs_trigo:
+
+Trigonometric functions
+-----------------------
+
+.. autosummary::
+   :toctree: _generated/
+
+    sin
+    cos
+    tan
+    arcsin
+    arccos
+    arctan
+    hypot
+    arctan2
+    degrees
+    radians
+    unwrap
+
+.. _ufuncs_hyper:
+
+Hyperbolic functions
+--------------------
+
+.. autosummary::
+   :toctree: _generated/
+
+   sinh
+   cosh
+   tanh
+   arcsinh
+   arccosh
+   arctanh
+
+.. _ufuncs_complex:
+
+Complex Numbers
+---------------
+
+.. autosummary::
+   :toctree: _generated/
+
+   angle
+   real
+   imag
+   conj
+
+.. _ufuncs_floating:
+
+Floating Point Routines
+-----------------------
+
+.. autosummary::
+   :toctree: _generated/
+
+   signbit
+   copysign
+   frexp
+   ldexp
 
 .. _api-metadata:
 

--- a/doc/source/changes/version_0_30.rst.inc
+++ b/doc/source/changes/version_0_30.rst.inc
@@ -219,3 +219,6 @@ Fixes
 
 * fixed maximum length of sheet names (31 characters instead of 30 characters) when adding a new sheet
   to an Excel Workbook (closes :issue:`713`).
+
+* fixed missing documentation of many functions in :ref:`Utility Functions <api-ufuncs>` section
+  of the API Reference (closes :issue:`698`).

--- a/doc/source/changes/version_0_30.rst.inc
+++ b/doc/source/changes/version_0_30.rst.inc
@@ -1,4 +1,6 @@
-﻿Syntax changes
+﻿.. py:currentmodule:: larray
+
+Syntax changes
 --------------
 
 * new syntax
@@ -210,6 +212,9 @@ Miscellaneous improvements
                  UK   6   8
 
   Closes :issue:`671`.
+
+* added documentation and examples for :py:obj:`where()`, :py:obj:`maximum()`
+  and :py:obj:`minimum()` functions (closes :issue:`700`)
 
 
 Fixes

--- a/larray/core/__init__.py
+++ b/larray/core/__init__.py
@@ -6,4 +6,5 @@ from larray.core.axis import *
 from larray.core.array import *
 from larray.core.session import *
 from larray.core.ufuncs import *
+from larray.core.npufuncs import *
 from larray.core.metadata import *

--- a/larray/core/array.py
+++ b/larray/core/array.py
@@ -5335,7 +5335,7 @@ class LArray(ABCLArray):
             if not nans_equal:
                 return self == other
             else:
-                from larray.core.ufuncs import isnan
+                from larray.core import isnan
 
                 def general_isnan(a):
                     if np.issubclass_(a.dtype.type, np.inexact):
@@ -6049,7 +6049,7 @@ class LArray(ABCLArray):
         -----
         If `a_min` and/or `a_max` are array_like, broadcast will occur between self, `a_min` and `a_max`.
         """
-        from larray.core.ufuncs import clip
+        from larray.core import clip
         return clip(self, a_min, a_max, out)
 
     @deprecate_kwarg('transpose', 'wide')

--- a/larray/core/npufuncs.py
+++ b/larray/core/npufuncs.py
@@ -1,0 +1,176 @@
+# numpy ufuncs -- this module is excluded from pytest
+# http://docs.scipy.org/doc/numpy/reference/routines.math.html
+
+import numpy as np
+
+from larray.core.ufuncs import broadcastify
+
+
+__all__ = [
+    # Trigonometric functions
+    'sin', 'cos', 'tan', 'arcsin', 'arccos', 'arctan', 'hypot', 'arctan2', 'degrees', 'radians', 'unwrap',
+    # 'deg2rad', 'rad2deg',
+
+    # Hyperbolic functions
+    'sinh', 'cosh', 'tanh', 'arcsinh', 'arccosh', 'arctanh',
+
+    # Rounding
+    'round', 'around', 'round_', 'rint', 'fix', 'floor', 'ceil', 'trunc',
+
+    # Sums, products, differences
+    # 'prod', 'sum', 'nansum', 'cumprod', 'cumsum',
+
+    # cannot use a simple wrapped ufunc because those ufuncs do not preserve shape or dimensions so labels are wrong
+    # 'diff', 'ediff1d', 'gradient', 'cross', 'trapz',
+
+    # Exponents and logarithms
+    'exp', 'expm1', 'exp2', 'log', 'log10', 'log2', 'log1p', 'logaddexp', 'logaddexp2',
+
+    # Other special functions
+    'i0', 'sinc',
+
+    # Floating point routines
+    'signbit', 'copysign', 'frexp', 'ldexp',
+
+    # Arithmetic operations
+    # 'add', 'reciprocal', 'negative', 'multiply', 'divide', 'power', 'subtract', 'true_divide', 'floor_divide',
+    # 'fmod', 'mod', 'modf', 'remainder',
+
+    # Handling complex numbers
+    'angle', 'real', 'imag', 'conj',
+
+    # Miscellaneous
+    'convolve', 'clip', 'sqrt',
+    # 'square',
+    'absolute', 'fabs', 'sign', 'fmax', 'fmin', 'nan_to_num', 'real_if_close',
+    'interp', 'isnan', 'isinf', 'inverse',
+]
+
+
+# Trigonometric functions
+
+sin = broadcastify(np.sin)
+cos = broadcastify(np.cos)
+tan = broadcastify(np.tan)
+arcsin = broadcastify(np.arcsin)
+arccos = broadcastify(np.arccos)
+arctan = broadcastify(np.arctan)
+hypot = broadcastify(np.hypot)
+arctan2 = broadcastify(np.arctan2)
+degrees = broadcastify(np.degrees)
+radians = broadcastify(np.radians)
+unwrap = broadcastify(np.unwrap)
+# deg2rad = broadcastify(np.deg2rad)
+# rad2deg = broadcastify(np.rad2deg)
+
+# Hyperbolic functions
+
+sinh = broadcastify(np.sinh)
+cosh = broadcastify(np.cosh)
+tanh = broadcastify(np.tanh)
+arcsinh = broadcastify(np.arcsinh)
+arccosh = broadcastify(np.arccosh)
+arctanh = broadcastify(np.arctanh)
+
+# Rounding
+
+# TODO: add examples for round, floor, ceil and trunc
+# all 3 are equivalent, I am unsure I should support around and round_
+round = broadcastify(np.round)
+around = broadcastify(np.around)
+round_ = broadcastify(np.round_)
+rint = broadcastify(np.rint)
+fix = broadcastify(np.fix)
+floor = broadcastify(np.floor)
+ceil = broadcastify(np.ceil)
+trunc = broadcastify(np.trunc)
+
+# Sums, products, differences
+
+# prod = broadcastify(np.prod)
+# sum = broadcastify(np.sum)
+# nansum = broadcastify(np.nansum)
+# cumprod = broadcastify(np.cumprod)
+# cumsum = broadcastify(np.cumsum)
+
+# cannot use a simple wrapped ufunc because those ufuncs do not preserve
+# shape or dimensions so labels are wrong
+# diff = broadcastify(np.diff)
+# ediff1d = broadcastify(np.ediff1d)
+# gradient = broadcastify(np.gradient)
+# cross = broadcastify(np.cross)
+# trapz = broadcastify(np.trapz)
+
+# Exponents and logarithms
+
+# TODO: add examples for exp and log
+exp = broadcastify(np.exp)
+expm1 = broadcastify(np.expm1)
+exp2 = broadcastify(np.exp2)
+log = broadcastify(np.log)
+log10 = broadcastify(np.log10)
+log2 = broadcastify(np.log2)
+log1p = broadcastify(np.log1p)
+logaddexp = broadcastify(np.logaddexp)
+logaddexp2 = broadcastify(np.logaddexp2)
+
+# Other special functions
+
+i0 = broadcastify(np.i0)
+sinc = broadcastify(np.sinc)
+
+# Floating point routines
+
+signbit = broadcastify(np.signbit)
+copysign = broadcastify(np.copysign)
+frexp = broadcastify(np.frexp)
+ldexp = broadcastify(np.ldexp)
+
+# Arithmetic operations
+
+# add = broadcastify(np.add)
+# reciprocal = broadcastify(np.reciprocal)
+# negative = broadcastify(np.negative)
+# multiply = broadcastify(np.multiply)
+# divide = broadcastify(np.divide)
+# power = broadcastify(np.power)
+# subtract = broadcastify(np.subtract)
+# true_divide = broadcastify(np.true_divide)
+# floor_divide = broadcastify(np.floor_divide)
+# fmod = broadcastify(np.fmod)
+# mod = broadcastify(np.mod)
+# modf = broadcastify(np.modf)
+# remainder = broadcastify(np.remainder)
+
+# Handling complex numbers
+
+angle = broadcastify(np.angle)
+real = broadcastify(np.real)
+imag = broadcastify(np.imag)
+conj = broadcastify(np.conj)
+
+# Miscellaneous
+
+convolve = broadcastify(np.convolve)
+clip = broadcastify(np.clip)
+# square = broadcastify(np.square)
+absolute = broadcastify(np.absolute)
+fabs = broadcastify(np.fabs)
+sign = broadcastify(np.sign)
+fmax = broadcastify(np.fmax)
+fmin = broadcastify(np.fmin)
+nan_to_num = broadcastify(np.nan_to_num)
+real_if_close = broadcastify(np.real_if_close)
+
+# TODO: add examples for functions below
+sqrt = broadcastify(np.sqrt)
+isnan = broadcastify(np.isnan)
+isinf = broadcastify(np.isinf)
+inverse = broadcastify(np.linalg.inv)
+
+# XXX: create a new LArray method instead ?
+# TODO: should appear in the API doc if it actually works with LArrays,
+#       which I have never tested (and I doubt is the case).
+#       Might be worth having specific documentation if it works well.
+#       My guess is that we should rather make a new LArray method for that one.
+interp = broadcastify(np.interp)

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test=pytest
 testpaths = larray
 # exclude (doc)tests from ufuncs (because docstrings are copied from numpy
 # and many of those doctests are failing
-addopts = -v --doctest-modules --ignore=larray/core/ufuncs.py --ignore=larray/ipfp
+addopts = -v --doctest-modules --ignore=larray/core/npufuncs.py --ignore=larray/ipfp
           --pep8
           #--cov
 # E122: continuation line missing indentation or outdented


### PR DESCRIPTION
readthedocs output is here: https://larray-test.readthedocs.io/en/documentation/api.html#utility-functions

I still need to find a way to run new specific doctests for ``where``, ``maximum`` and ``minimum`` but let's start the discussion.

Issues #715 and #716 will be fixed in another PR.