### PR TITLE
documentation: updated readthedocs.yml to the version 2 + updated python version to 3.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,9 @@ For IO (HDF, Excel)
 
 - `pytables <http://www.pytables.org/>`__:
   for working with files in HDF5 format.
+- `xlwings <https://www.xlwings.org/>`__:
+  recommended package to get benefit of all Excel features of LArray.
+  Only available on Windows and Mac platforms.
 - `xlrd <http://www.python-excel.org/>`__:
   for reading data and formatting information from older Excel files (ie: .xls)
 - `openpyxl <http://www.python-excel.org/>`__:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.5
+  - python=3.6
   - numpy
   - pandas
   - matplotlib

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
 conda:
-    file: doc/environment.yml
+    environment: doc/environment.yml
+
+# Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3
-   setup_py_install: true
+   version: 3.6
+   install:
+      - method: setuptools
+        path: .


### PR DESCRIPTION
It is always a great to discover that Readthedocs made some internal changes a few time ago and that changes break all your build attempts until you implement the necessary updates =D

The present commit seems to solve the problem:
https://readthedocs.org/projects/larray-test/builds/9121630/