### PR TITLE
updated dependencies requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,13 @@
 # References
 # - https://gist.github.com/dan-blanchard/7045057
 # - https://github.com/numba/numba/blob/master/.travis.yml
+dist: xenial         # required for Python >= 3.7
 language: python
 
 python:
     - "2.7"
-    - "3.5"
     - "3.6"
-
-# Work-around to enable python 3.7 without globally enabling sudo and dist: xenial for other build jobs
-# see https://github.com/travis-ci/travis-ci/issues/9815
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+    - "3.7"
 
 branches:
     only:
@@ -44,12 +37,10 @@ install:
     # - pandas will bring dateutil numpy pytz setuptools six and scipy, we
     #   might want to avoid the later by installing all dependencies manually
     #   except scipy and install pandas with --no-deps
-    # - fixed versions of numpy and pytables because of incompatibilities
-    #   between pytables <= 3.4 and numpy >= 1.16
     # - pandas >= 0.20.0 is required since commit 01669f2024a7bffe47cceec0a0fd845f71b6f7cc
     #   (issue 702 : fixed bug when writing metadata using HDF format)
     - conda create -n travisci --yes python=${TRAVIS_PYTHON_VERSION:0:3}
-            "numpy==1.15.2" "pandas>=0.20" "pytables==3.4.4" matplotlib xlrd openpyxl
+            "numpy>=1.13" "pandas>=0.20" pytables matplotlib xlrd openpyxl
             xlsxwriter pytest pytest-pep8
     - source activate travisci
 

--- a/condarecipe/larray/meta.yaml
+++ b/condarecipe/larray/meta.yaml
@@ -21,7 +21,7 @@ requirements:
 
   run:
     - python
-    - numpy >=1.13,!= 1.16
+    - numpy >=1.13
     - pandas >=0.20
 
 test:

--- a/make_release.py
+++ b/make_release.py
@@ -39,14 +39,11 @@ def update_metapackage(context):
 
     # TODO: this should be echocall(redirect_stdout=False)
     print(fill('Updating larrayenv metapackage to version {version}'))
-    # - fixed versions of numpy and pytables because of incompatibilities
-    #   between pytables <= 3.4 and numpy >= 1.16
-    #   Didn't set pytables ==3.5 because it is not available for Python 3.5
     # - excluded versions 5.0 and 5.1 of ipykernel because these versions make the console useless after any exception
     #   https://github.com/larray-project/larray-editor/issues/166
     check_call(['conda', 'metapackage', 'larrayenv', version, '--dependencies', fill('larray =={version}'),
                 fill('larray-editor =={version}'), fill('larray_eurostat =={version}'),
-                "qtconsole", "matplotlib", "pyqt", "qtpy", "numpy ==1.15.2", "pytables ==3.4.4",
+                "qtconsole", "matplotlib", "pyqt", "qtpy", "pytables",
                 "xlsxwriter", "xlrd", "openpyxl", "xlwings", "ipykernel !=5.0,!=5.1.0",
                 '--home', 'http://github.com/larray-project/larray',
                 '--license', 'GPL-3.0',

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ test=pytest
 testpaths = larray
 # - exclude (doc)tests from ufuncs (because docstrings are copied from numpy
 #   and many of those doctests are failing
-# - deselect LArray.astype since doctests fails for Python 3.6 and numpy => 1.17
+# - deselect LArray.astype since doctests fails for Python 3.6 and numpy >= 1.17
 addopts = -v --doctest-modules
           --ignore=larray/core/npufuncs.py
           --ignore=larray/ipfp

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,14 @@ test=pytest
 
 [tool:pytest]
 testpaths = larray
-# exclude (doc)tests from ufuncs (because docstrings are copied from numpy
-# and many of those doctests are failing
+# - exclude (doc)tests from ufuncs (because docstrings are copied from numpy
+#   and many of those doctests are failing
+# - deselect LArray.astype since doctests fails for Python 3.6 and numpy => 1.17
 addopts = -v --doctest-modules
           --ignore=larray/core/npufuncs.py
           --ignore=larray/ipfp
           --ignore=larray/inout/xw_reporting.py
+          --deselect larray/core/array.py::larray.core.array.LArray.astype
           --pep8
           #--cov
 # E122: continuation line missing indentation or outdented

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,9 @@ AUTHOR_EMAIL = 'gdementen@gmail.com'
 DESCRIPTION = "N-D labeled arrays in Python"
 LONG_DESCRIPTION = readlocal("README.rst")
 SETUP_REQUIRES = []
-# - excludes numpy 1.16.* because it is incompatible with pytables < 3.5
 # - pandas >= 0.20.0 is required since commit 01669f2024a7bffe47cceec0a0fd845f71b6f7cc
 #   (issue 702 : fixed bug when writing metadata using HDF format)
-INSTALL_REQUIRES = ['numpy >= 1.13, != 1.16.*', 'pandas >= 0.20.0']
+INSTALL_REQUIRES = ['numpy >= 1.13', 'pandas >= 0.20.0']
 TESTS_REQUIRE = ['pytest', 'pytest-pep8']
 
 LICENSE = 'GPLv3'


### PR DESCRIPTION
- removed exclusion of numpy==1.16.* version since pytables 3.5 is now available and fixed the incompatibility
- set condition pytables>=3.5 in travis.yml and larrayenv metapackage
- dropped support Python 3.5 in travis.yml
- updated travis.yml for Python 3.7 (both "dist: xenial" and "sudo: true" are the default now)