### PR TITLE
fixed X.axis_name[groups] when groups have the same axis name (closes #787)

### DIFF
--- a/doc/source/changes/version_0_31.rst.inc
+++ b/doc/source/changes/version_0_31.rst.inc
@@ -1,33 +1,11 @@
 ﻿.. py:currentmodule:: larray
 
 
-Syntax changes
-^^^^^^^^^^^^^^
-
-* renamed ``LArray.old_method_name()`` to :py:obj:`LArray.new_method_name()` (closes :issue:`1`).
-
-* renamed ``old_argument_name`` argument of :py:obj:`LArray.method_name()` to ``new_argument_name``.
-
-
-Backward incompatible changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* other backward incompatible changes
-
-
 New features
 ^^^^^^^^^^^^
 
 * added the :py:obj:`ExcelReport` class allowing to generate multiple graphs in an
   Excel file at once (closes :issue:`676`).
-
-
-.. _misc:
-
-Miscellaneous improvements
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-* improved the performance of a few LArray methods.
 
 
 Fixes
@@ -39,3 +17,6 @@ Fixes
 * fixed taking a subset of an array with boolean labels for an axis if the user explicitly specify the axis
   (closes :issue:`735`). When the user does not specify the axis, it currently fails but it is unclear what to do in
   that case (see :issue:`794`).
+
+* fixed a regression in 0.30: X.axis_name[groups] failed when groups were originally defined on axes with the same name
+  (i.e. when the operation was not actually needed). Closes :issue:`787`.

--- a/larray/core/axis.py
+++ b/larray/core/axis.py
@@ -758,7 +758,10 @@ class Axis(ABCAxis):
             list_res = [self[k] for k in key]
             return list_res if isinstance(key, list) else tuple(list_res)
         # allow targeting a label from an aggregated axis with the group which created it
-        elif (isinstance(key, Group) and isinstance(key.axis, Axis) and key.axis.name == self.name and
+        elif (not isinstance(self, AxisReference) and
+              isinstance(key, Group) and
+              isinstance(key.axis, Axis) and
+              key.axis.name == self.name and
               key.name in self):
             return LGroup(key.name, None, self)
         # elif isinstance(key, basestring) and key in self:


### PR DESCRIPTION
i.e. when the operation was not actually needed