### PR TITLE
fix #868: fixed edge case for group aggregates

### DIFF
--- a/doc/source/changes/version_0_33.rst.inc
+++ b/doc/source/changes/version_0_33.rst.inc
@@ -58,4 +58,4 @@ Miscellaneous improvements
 Fixes
 ^^^^^
 
-* fixed something (closes :issue:`000`).
+* fixed an edge case for group aggregates and labels in reverse order (closes :issue:`868`).

--- a/larray/core/axis.py
+++ b/larray/core/axis.py
@@ -10,7 +10,7 @@ import pandas as pd
 from larray.core.abstractbases import ABCAxis, ABCAxisReference, ABCArray
 from larray.core.expr import ExprNode
 from larray.core.group import (Group, LGroup, IGroup, IGroupMaker, _to_tick, _to_ticks, _to_key, _seq_summary,
-                               _range_to_slice, _seq_group_to_name, _translate_group_key_hdf, remove_nested_groups)
+                               _idx_seq_to_slice, _seq_group_to_name, _translate_group_key_hdf, remove_nested_groups)
 from larray.util.oset import *
 from larray.util.misc import (duplicates, array_lookup2, ReprString, index_by_id, renamed_to, common_type, LHDFStore,
                               lazy_attribute, _isnoneslice, unique_multi, Product)
@@ -2798,7 +2798,7 @@ class AxisCollection(object):
             seq_types = (tuple, list, np.ndarray)
             # TODO: we should only do this if there are no Array key (with axes corresponding to the range)
             # otherwise we will be translating them back to a range afterwards
-            key = [_range_to_slice(axis_key, len(axis)) if isinstance(axis_key, seq_types) else axis_key
+            key = [_idx_seq_to_slice(axis_key, len(axis)) if isinstance(axis_key, seq_types) else axis_key
                    for axis_key, axis in zip(key, self)]
 
         # transform non-Array advanced keys (list and ndarray) to Array

--- a/larray/tests/test_array.py
+++ b/larray/tests/test_array.py
@@ -1887,6 +1887,10 @@ def test_group_agg_guess_axis(array):
     res = array.sum(age, sex).sum((vla, wal, bru, belgium))
     assert res.shape == (4, 15)
 
+    # issue #868: labels in reverse order with a "step" between them > index of last label
+    arr = ndtest(4)
+    assert arr.sum('a3,a1') == 4
+
 
 def test_group_agg_label_group(array):
     age, geo, sex, lipro = array.axes


### PR DESCRIPTION
the bug occurred only if all the following conditions applied:
a) the labels indices were at a constant "step" from each other
b) they were given in reverse order (step < 0)
c) the last label (with smallest index) had an index < abs(step) (ie index + step < 0)