### PR TITLE
Finalize add of return type hints

### DIFF
--- a/doc/source/changes/version_0_34.rst.inc
+++ b/doc/source/changes/version_0_34.rst.inc
@@ -52,6 +52,8 @@ Miscellaneous improvements
 * made all I/O functions/methods/constructors to accept either a string or a pathlib.Path object
   for all arguments representing a path (closes :issue:`896`).
 
+* added type hints for all remaining functions and methods which improves autocompletion in editors (such as PyCharm).
+  Closes :issue:`864`.
 
 Fixes
 ^^^^^

--- a/larray/core/array.py
+++ b/larray/core/array.py
@@ -5631,7 +5631,7 @@ class Array(ABCArray):
         fullname = f'__{opname}__'
         super_method = getattr(np.ndarray, fullname)
 
-        def opmethod(self, other):
+        def opmethod(self, other) -> 'Array':
             res_axes = self.axes
 
             if isinstance(other, ExprNode):
@@ -5794,7 +5794,7 @@ class Array(ABCArray):
         fullname = f'__{opname}__'
         super_method = getattr(np.ndarray, fullname)
 
-        def opmethod(self):
+        def opmethod(self) -> 'Array':
             return Array(super_method(self.data), self.axes)
         opmethod.__name__ = fullname
         return opmethod

--- a/larray/core/axis.py
+++ b/larray/core/axis.py
@@ -333,7 +333,7 @@ class Axis(ABCAxis):
             Names of resulting axes. Defaults to None.
         regex : str, optional
             Use regex instead of delimiter to split labels. Defaults to None.
-        labels : bool, optional
+        return_labels : bool, optional
             Whether or not split labels must be returned (as a tuple of tuples). These labels are suitable for indexing
             via array.points[labels]. Defaults to False.
 

--- a/larray/core/checked.py
+++ b/larray/core/checked.py
@@ -58,7 +58,7 @@ else:
             yield cls.validate
 
         @classmethod
-        def validate(cls, value, field: ModelField):
+        def validate(cls, value, field: ModelField) -> Array:
             if not (isinstance(value, Array) or np.isscalar(value)):
                 raise TypeError(f"Expected object of type '{Array.__name__}' or a scalar for "
                                 f"the variable '{field.name}' but got object of type '{type(value).__name__}'")
@@ -504,7 +504,7 @@ else:
         def __setstate__(self, state: Dict[str, Any]) -> None:
             object.__setattr__(self, '__dict__', state['__dict__'])
 
-        def dict(self, exclude: Set[str] = None):
+        def dict(self, exclude: Set[str] = None) -> Dict[str, Any]:
             return {k: v for k, v in self.items() if k not in exclude}
 
     class CheckedParameters(CheckedSession):

--- a/larray/core/metadata.py
+++ b/larray/core/metadata.py
@@ -1,6 +1,9 @@
 from collections import OrderedDict
 
+from typing import List, Optional
 
+
+# FIXME : inherit from dict
 class AttributeDict(OrderedDict):
     def __getattr__(self, key):
         try:
@@ -14,10 +17,10 @@ class AttributeDict(OrderedDict):
     def __delattr__(self, key):
         del self[key]
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         return list(set(super(AttributeDict, self).__dir__()) | set(self.keys()))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '\n'.join([f'{k}: {v}' for k, v in self.items()])
 
 
@@ -57,7 +60,7 @@ class Metadata(AttributeDict):
         return stack(self.items(), axes='metadata')
 
     @classmethod
-    def from_array(cls, array):
+    def from_array(cls, array) -> 'Metadata':
         from larray.core.array import asarray
         array = asarray(array)
         if array.ndim != 1:
@@ -80,7 +83,7 @@ class Metadata(AttributeDict):
             attrs.metadata = self
 
     @classmethod
-    def from_hdf(cls, hdfstore, key=None):
+    def from_hdf(cls, hdfstore, key=None) -> Optional['Metadata']:
         attrs = hdfstore.get_storer(key).attrs if key is not None else hdfstore.root._v_attrs
         if 'metadata' in attrs:
             return attrs.metadata

--- a/larray/random.py
+++ b/larray/random.py
@@ -34,7 +34,7 @@ import larray as la                                     # noqa: F401
 __all__ = ['randint', 'normal', 'uniform', 'permutation', 'choice']
 
 
-def generic_random(np_func, args, min_axes, meta):
+def generic_random(np_func, args, min_axes, meta) -> Array:
     args, res_axes = raw_broadcastable(args, min_axes=min_axes)
     res_data = np_func(*args, size=res_axes.shape)
     return Array(res_data, res_axes, meta=meta)
@@ -43,7 +43,7 @@ def generic_random(np_func, args, min_axes, meta):
 # We choose to place the axes argument in place of the numpy size argument, instead of having axes as the first
 # argument, because that would make it ugly for scalars. As a consequence, it is slightly ugly when arguments
 # before axes are not required.
-def randint(low, high=None, axes=None, dtype='l', meta=None):
+def randint(low, high=None, axes=None, dtype='l', meta=None) -> Array:
     r"""Return random integers from `low` (inclusive) to `high` (exclusive).
 
     Return random integers from the "discrete uniform" distribution of the specified dtype in the "half-open" interval
@@ -122,7 +122,7 @@ def randint(low, high=None, axes=None, dtype='l', meta=None):
     return generic_random(np.random.randint, (low, high), axes, meta)
 
 
-def normal(loc=0.0, scale=1.0, axes=None, meta=None):
+def normal(loc=0.0, scale=1.0, axes=None, meta=None) -> Array:
     r"""
     Draw random samples from a normal (Gaussian) distribution.
 
@@ -229,7 +229,7 @@ def normal(loc=0.0, scale=1.0, axes=None, meta=None):
     return generic_random(np.random.normal, (loc, scale), axes, meta)
 
 
-def uniform(low=0.0, high=1.0, axes=None, meta=None):
+def uniform(low=0.0, high=1.0, axes=None, meta=None) -> Array:
     r"""
     Draw samples from a uniform distribution.
 
@@ -331,7 +331,7 @@ def uniform(low=0.0, high=1.0, axes=None, meta=None):
     return generic_random(np.random.uniform, (low, high), axes, meta)
 
 
-def permutation(x, axis=0):
+def permutation(x, axis=0) -> Array:
     r"""
     Randomly permute a sequence along an axis, or return a permuted range.
 
@@ -380,7 +380,7 @@ def permutation(x, axis=0):
         return x[g]
 
 
-def choice(choices=None, axes=None, replace=True, p=None, meta=None):
+def choice(choices=None, axes=None, replace=True, p=None, meta=None) -> Array:
     r"""
     Generates a random sample from given choices
 

--- a/larray/util/types.py
+++ b/larray/util/types.py
@@ -1,6 +1,7 @@
-from typing import Union, TypeVar
-from numpy import generic
+from typing import Union, TypeVar, List
+from numpy import generic, ndarray
 
 R = TypeVar('R')
 
 Scalar = Union[bool, int, float, str, bytes, generic]
+Key = Union[Scalar, 'Group', 'Array', ndarray, 'OrderedSet', List[Scalar], slice]   # noqa: F821


### PR DESCRIPTION
@gdementen I wonder if we shouldn't either define [L|I]GroupKey types in types.py or even make them classes (there are a lot of private functions in group.py ? 